### PR TITLE
Switch to fastcgi.conf on nginx >= 1.6.1

### DIFF
--- a/templates/etc/nginx/sites-available/php5.conf.j2
+++ b/templates/etc/nginx/sites-available/php5.conf.j2
@@ -55,7 +55,11 @@
                 try_files $script_name =404;
 
 {% if (item.php5_include is undefined or (item.php5_include is defined and item.php5_include)) %}
+{% if (nginx_version is defined and nginx_version.stdout | version_compare('1.6.1','<')) %}
                 include {{ item.php5_include | default('fastcgi_params') }};
+{% else %}
+                include {{ item.php5_include | default('fastcgi.conf') }};
+{% endif %}
 
 {% endif %}
 {% if item.php5_options is defined and item.php5_options %}


### PR DESCRIPTION
In accordance with
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=718639 nginx PHP5
configuration will now check the installed nginx version and correctly
pick old 'fastcgi_params' or new 'fastcgi.conf' configuration file to
include in the server configuration for PHP5 applications.
