### PR TITLE
Automatically select one nginx server as default

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -151,3 +151,19 @@
   when: ((nginx_register_installed is defined and nginx_register_installed) and
          not nginx_register_installed.stat.exists)
 
+- name: Make sure that Ansible local facts directory is present
+  file:
+    path: '/etc/ansible/facts.d'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+
+- name: Save nginx local facts
+  template:
+    src: 'etc/ansible/facts.d/nginx.fact.j2'
+    dest: '/etc/ansible/facts.d/nginx.fact'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+

--- a/tasks/nginx_servers.yml
+++ b/tasks/nginx_servers.yml
@@ -21,6 +21,24 @@
   when: ((item.locked is undefined or (item.locked is defined and not item.locked)) and
          (item.name is defined) and (item.delete is defined and item.delete))
 
+- name: Check if default server is in the list of nginx servers
+  set_fact:
+    nginx_register_default_server_name: '{{ nginx_default_name }}'
+  with_items: [ '{{ nginx_servers }}' ]
+  when: ((nginx_default_name is defined and nginx_default_name) and
+         (item.name is defined and nginx_default_name in item.name))
+
+- name: Check if one of servers is marked as default
+  set_fact:
+    nginx_register_default_server_specified: '{{ item.name[0] | default("default") }}'
+  with_items: [ '{{ nginx_servers }}' ]
+  when: (item.name is defined) and (item.default is defined and item.default)
+
+- name: Select first configured server as default if default not set
+  set_fact:
+    nginx_register_default_server_first: '{{ nginx_servers[0].name[0] | default("default") }}'
+  when: (nginx_register_default_server_specified is undefined or
+         (nginx_register_default_server_specified is defined and not nginx_register_default_server_specified))
 
 - name: Generate nginx server configuration
   template:

--- a/templates/etc/ansible/facts.d/nginx.fact.j2
+++ b/templates/etc/ansible/facts.d/nginx.fact.j2
@@ -1,0 +1,16 @@
+{% set nginx_tpl_default_server = ''                                              %}
+{% if ((ansible_local is defined and ansible_local) and
+       (ansible_local.nginx is defined and ansible_local.nginx) and
+       (ansible_local.nginx.default_server is defined and ansible_local.nginx.default_server)) %}
+{%   set nginx_tpl_default_server = ansible_local.nginx.default_server            %}
+{% elif ((nginx_default_name is defined and nginx_default_name) and
+         (nginx_register_default_server_name is defined and nginx_register_default_server_name)) %}
+{%   set nginx_tpl_default_server = nginx_register_default_server_name            %}
+{% elif (nginx_register_default_server_specified is defined and nginx_register_default_server_specified) %}
+{%   set nginx_tpl_default_server = nginx_register_default_server_specified       %}
+{% elif (nginx_register_default_server_first is defined and nginx_register_default_server_first) %}
+{%   set nginx_tpl_default_server = nginx_register_default_server_first           %}
+{% endif                                                                          %}
+{
+"default_server": "{{ nginx_tpl_default_server }}"
+}

--- a/templates/etc/nginx/sites-available/default.conf.j2
+++ b/templates/etc/nginx/sites-available/default.conf.j2
@@ -22,6 +22,12 @@
         (item.name is defined and item.name) and
         (nginx_default_name in item.name) and
         (item.default is undefined or (item.default is defined and item.default))) or
+       ((ansible_local is defined and ansible_local) and
+        (ansible_local.nginx is defined and ansible_local.nginx) and
+        (ansible_local.nginx.default_server is defined and ansible_local.nginx.default_server) and
+        (ansible_local.nginx.default_server in item.name)) or
+       ((nginx_register_default_server_first is defined and nginx_register_default_server_first) and
+        (nginx_register_default_server_first in item.name)) or
        (item.name is undefined))                                               %}
 {%     set nginx_tpl_default_server = 'default_server ipv6only=off'            %}
 {% endif                                                                       %}


### PR DESCRIPTION
Currently nginx server listens both on IPv4 and IPv6 networks, however
only IPv6 network is enabled by default. To make things simplier,
a directive 'ipv6only=off' which only needs to be present once, is tied
to 'default_server' directive.

Result of that decision is a requirement that at least one nginx server
must be set as the default, otherwise IPv4 traffic won't be accepted by
nginx. Code in this commit enables that function - it checks if a server
with name defined in 'nginx_default_name' variable is present among the
list of servers, if not, it checks if a server with 'item.default: True'
is present, otherwise the first server in 'nginx_servers' list is
selected as the default. The server name that has been picked is saved
in local facts, so that nginx role configures all servers correctly.
