### PR TITLE
Restart nginx on significant config changes

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Test nginx and restart
+  command: nginx -t
+  notify: Restart nginx
+
 - name: Test nginx and reload
   command: nginx -t
   notify: Reload nginx

--- a/tasks/nginx_servers.yml
+++ b/tasks/nginx_servers.yml
@@ -57,7 +57,7 @@
     path: '/etc/nginx/sites-enabled/{{ item.name[0] | default("default") }}.conf'
     state: 'absent'
   with_items: [ '{{ nginx_servers }}' ]
-  notify: [ 'Test nginx and reload' ]
+  notify: [ 'Test nginx and restart' ]
   when: (((item.enabled is defined and not item.enabled) and (item.name is defined)) or
         (item.delete is defined and item.delete))
 
@@ -70,7 +70,7 @@
     group: 'root'
     mode: '0644'
   with_items: [ '{{ nginx_servers }}' ]
-  notify: [ 'Test nginx and reload' ]
+  notify: [ 'Test nginx and restart' ]
   when: ((item.enabled is undefined or (item.enabled is defined and item.enabled)) and
          (item.name is defined) and (item.delete is undefined or (item.delete is defined and not item.delete)))
 


### PR DESCRIPTION
When nginx ports or listen configuration changes, server needs to be
restarted and not just reloaded. Since there's no useful indicator when
this should happen, nginx will be restarted when status of symlinks in
/etc/nginx/sites-enabled/ will change (symlinks are added or removed),
config modification will still result in reload only.
