### PR TITLE
Fix support for 'ansible-playbook --check' mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,8 +20,12 @@
 
 - name: Check nginx version
   shell: /usr/sbin/nginx -v 2>&1 | sed -e 's#^.*/##'
-  register: nginx_version
+  register: nginx_register_version
   changed_when: False
+
+- name: Define nginx version
+  set_fact:
+    nginx_version: '{{ nginx_register_version.stdout | default("0.0") }}'
 
 - name: Get list of nameservers configured in /etc/resolv.conf
   shell: grep nameserver /etc/resolv.conf | awk '{print $2}' | sed -e 'N;s/\n/ /'
@@ -31,8 +35,9 @@
 - name: Convert list of nameservers to Ansible list
   set_fact:
     nginx_ocsp_resolvers: "{{ nginx_register_nameservers.stdout.split(' ') }}"
-  when: (nginx_ocsp_resolvers is undefined or
-         (nginx_ocsp_resolvers is defined and not nginx_ocsp_resolvers))
+  when: ((nginx_register_nameservers.stdout is defined and nginx_register_nameservers.stdout) and
+         (nginx_ocsp_resolvers is undefined or
+         (nginx_ocsp_resolvers is defined and not nginx_ocsp_resolvers)))
 
 - name: Create default nginx directories
   file:

--- a/templates/etc/nginx/sites-available/default.conf.j2
+++ b/templates/etc/nginx/sites-available/default.conf.j2
@@ -458,7 +458,7 @@ server {
 server {
 {% endif %}
 {% for port in nginx_tpl_listen_ssl %}
-        listen {{ port }} ssl{% if (nginx_version is defined and nginx_version.stdout | version_compare('1.4','>=')) %} spdy{% endif %}{% if (loop.first and nginx_tpl_default_server) %} {{ nginx_tpl_default_server }}{% endif %};
+        listen {{ port }} ssl{% if (nginx_version is defined and nginx_version | version_compare('1.4','>=')) %} spdy{% endif %}{% if (loop.first and nginx_tpl_default_server) %} {{ nginx_tpl_default_server }}{% endif %};
 {% endfor %}
 
         ssl_certificate           {{ nginx_tpl_ssl_certificate }};
@@ -468,7 +468,7 @@ server {
         ssl_ciphers               "{{ nginx_ssl_ciphers[item.ssl_ciphers | default(nginx_default_ssl_ciphers)] }}"; # SSL cipher list: {{ item.ssl_ciphers | default(nginx_default_ssl_ciphers) }}
         ssl_dhparam               /etc/nginx/dhparam_2048.pem;
         ssl_ecdh_curve            {{ item.ssl_curve | default(nginx_default_ssl_curve) }};
-{% if (nginx_version is defined and nginx_version.stdout | version_compare('1.4','>=')) and nginx_ocsp_resolvers is defined and nginx_ocsp_resolvers %}
+{% if (nginx_version is defined and nginx_version | version_compare('1.4','>=')) and nginx_ocsp_resolvers is defined and nginx_ocsp_resolvers %}
         ssl_stapling              on;
         ssl_stapling_verify       on;
 {% set nginx_tpl_ocsp_resolver = nginx_ocsp_resolvers[0] if '.' in nginx_ocsp_resolvers[0] else '[' + nginx_ocsp_resolvers[0] + ']' %}

--- a/templates/etc/nginx/sites-available/php5.conf.j2
+++ b/templates/etc/nginx/sites-available/php5.conf.j2
@@ -55,7 +55,7 @@
                 try_files $script_name =404;
 
 {% if (item.php5_include is undefined or (item.php5_include is defined and item.php5_include)) %}
-{% if (nginx_version is defined and nginx_version.stdout | version_compare('1.6.1','<')) %}
+{% if (nginx_version is defined and nginx_version | version_compare('1.6.1','<')) %}
                 include {{ item.php5_include | default('fastcgi_params') }};
 {% else %}
                 include {{ item.php5_include | default('fastcgi.conf') }};


### PR DESCRIPTION
These changes should allow 'ansible-playbook --check' mode to pass
correctly and not stop the Ansible run due to missing variables.
