### PR TITLE
Check if ansible_local exists before descending

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,10 +29,10 @@ nginx_server_names_hash_max_size: 512
 nginx_default_keepalive_timeout: 60
 
 # PKI base directory. Set to False to disable SSL/TLS support
-nginx_pki: '{% if ansible_local.pki is defined %}{{ ansible_local.pki.base_path }}{% else %}/etc/pki{% endif %}'
+nginx_pki: '{% if (ansible_local is defined and ansible_local.pki is defined) %}{{ ansible_local.pki.base_path }}{% else %}/etc/pki{% endif %}'
 
 # PKI realm to use for nginx
-nginx_pki_realm: '{% if ansible_local.pki is defined %}{{ ansible_local.pki.realm }}{% else %}system{% endif %}'
+nginx_pki_realm: '{% if (ansible_local is defined and ansible_local.pki is defined) %}{{ ansible_local.pki.realm }}{% else %}system{% endif %}'
 
 # Path to default certificate, key and DH parameters file used by all nginx
 # servers if not specified otherwise in server configuration. Relative to


### PR DESCRIPTION
If 'ansible_local' is undefined, checking if 'ansible_local.pki' is
defined triggers an error. These checks need to be performed on every
level.