### PR TITLE
Split 'nginx_pki' into 'nginx_pki_path'

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,8 +28,11 @@ nginx_server_names_hash_max_size: 512
 
 nginx_default_keepalive_timeout: 60
 
-# PKI base directory. Set to False to disable SSL/TLS support
-nginx_pki: '{% if (ansible_local is defined and ansible_local.pki is defined) %}{{ ansible_local.pki.base_path }}{% else %}/etc/pki{% endif %}'
+# Enable or disable support for PKI/SSL/TLS in nginx
+nginx_pki: True
+
+# PKI base directory
+nginx_pki_path: '{% if (ansible_local is defined and ansible_local.pki is defined) %}{{ ansible_local.pki.base_path }}{% else %}/etc/pki{% endif %}'
 
 # PKI realm to use for nginx
 nginx_pki_realm: '{% if (ansible_local is defined and ansible_local.pki is defined) %}{{ ansible_local.pki.realm }}{% else %}system{% endif %}'

--- a/templates/etc/nginx/sites-available/default.conf.j2
+++ b/templates/etc/nginx/sites-available/default.conf.j2
@@ -285,17 +285,17 @@
 
     ---- SSL certificate ----
 #}
-{% set nginx_tpl_ssl_certificate = nginx_pki + "/" + item.pki_realm | default(nginx_pki_realm) + "/" + item.pki_crt | default(nginx_pki_crt) %}
+{% set nginx_tpl_ssl_certificate = nginx_pki_path + "/" + item.pki_realm | default(nginx_pki_realm) + "/" + item.pki_crt | default(nginx_pki_crt) %}
 {#
 
     ---- SSL certificate key ----
 #}
-{% set nginx_tpl_ssl_certificate_key = nginx_pki + "/" + item.pki_realm | default(nginx_pki_realm) + "/" + item.pki_key | default(nginx_pki_key) %}
+{% set nginx_tpl_ssl_certificate_key = nginx_pki_path + "/" + item.pki_realm | default(nginx_pki_realm) + "/" + item.pki_key | default(nginx_pki_key) %}
 {#
 
     ---- Diffie-Hellman Key Exchange parameters ----
 #}
-{% set nginx_tpl_ssl_dhparam = nginx_pki + "/" + item.pki_realm | default(nginx_pki_realm) + "/" + item.pki_dhparam | default(nginx_pki_dhparam) %}
+{% set nginx_tpl_ssl_dhparam = nginx_pki_path + "/" + item.pki_realm | default(nginx_pki_realm) + "/" + item.pki_dhparam | default(nginx_pki_dhparam) %}
 {#
 
     ---- root directory ----


### PR DESCRIPTION
If that variable was set to False, Ansible couldn't add bool with
string, so functionality is now split - 'nginx_pki' enables or disables
SSL/TLS support in nginx globally, and 'nginx_pki_path' contains base
path to the PKI directory.