### PR TITLE
Add 'item.filename' key in nginx configuration

### DIFF
--- a/tasks/nginx_servers.yml
+++ b/tasks/nginx_servers.yml
@@ -27,7 +27,7 @@
 
 - name: Remove nginx server configuration if requested
   file:
-    path: '/etc/nginx/sites-available/{{ item.name[0] | default("default") }}.conf'
+    path: '/etc/nginx/sites-available/{{ item.filename | default(item.name[0] | default("default")) }}.conf'
     state: 'absent'
   with_items: [ '{{ nginx_servers }}' ]
   notify: [ 'Test nginx and reload' ]
@@ -62,7 +62,7 @@
 - name: Generate nginx server configuration
   template:
     src: 'etc/nginx/sites-available/{{ item.type | default(nginx_default_type) }}.conf.j2'
-    dest: '/etc/nginx/sites-available/{{ item.name[0] | default("default") }}.conf'
+    dest: '/etc/nginx/sites-available/{{ item.filename | default(item.name[0] | default("default")) }}.conf'
     owner: 'root'
     group: 'root'
     mode: '0644'
@@ -73,7 +73,7 @@
 
 - name: Disable nginx server configuration
   file:
-    path: '/etc/nginx/sites-enabled/{{ item.name[0] | default("default") }}.conf'
+    path: '/etc/nginx/sites-enabled/{{ item.filename | default(item.name[0] | default("default")) }}.conf'
     state: 'absent'
   with_items: [ '{{ nginx_servers }}' ]
   notify: [ 'Test nginx and restart' ]
@@ -82,8 +82,8 @@
 
 - name: Enable nginx server configuration
   file:
-    path: '/etc/nginx/sites-enabled/{{ item.name[0] | default("default") }}.conf'
-    src: '/etc/nginx/sites-available/{{ item.name[0] | default("default") }}.conf'
+    path: '/etc/nginx/sites-enabled/{{ item.filename | default(item.name[0] | default("default")) }}.conf'
+    src: '/etc/nginx/sites-available/{{ item.filename | default(item.name[0] | default("default")) }}.conf'
     state: 'link'
     owner: 'root'
     group: 'root'

--- a/templates/etc/nginx/sites-available/default.conf.j2
+++ b/templates/etc/nginx/sites-available/default.conf.j2
@@ -21,6 +21,13 @@
 #       configuration its included in will be named as 'default'.
 #
 #
+#   - item.filename: ''
+#       Optional. Alternative name of the nginx configuration file in
+#       '/etc/nginx/' directory, prefix '.conf' will be added automatically.
+#       Can be used to distinguish between different versions of the same
+#       configuration - for example separate configuration for HTTP and HTTPS.
+#
+#
 #   - item.default: True/False
 #       Optional. Marks this server configuration as the "default_server", if
 #       nginx cannot find correct server name or listen address to pass the


### PR DESCRIPTION
You can use 'item.filename' key in nginx server configuration dicts to
specify alternative name of the config file generated for this server.