### PR TITLE
Use correct address range for localhost

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -82,7 +82,7 @@ nginx_webroot_mode: '0755'
 nginx_status: []
 
 # By default allow access to the status page from webserver itself
-nginx_status_localhost: '{{ [ "127.0.0.1/8", "::1/128" ] + ansible_all_ipv4_addresses + ansible_all_ipv6_addresses }}'
+nginx_status_localhost: '{{ [ "127.0.0.1/32", "::1/128" ] + ansible_all_ipv4_addresses + ansible_all_ipv6_addresses }}'
 
 # Name of the nginx status page location
 nginx_status_name: '/nginx_status'


### PR DESCRIPTION
This will stop nginx warning about meaningless low address bits.