### PR TITLE
Expose default /srv/www path in local facts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -68,8 +68,12 @@ nginx_default_name: '{{ ansible_fqdn }}'
 # Default server template used if no type is selected
 nginx_default_type: 'default'
 
+# nginx base path for website directories
+# It is exposed using Ansible local facts as 'ansible_local.nginx.www'
+nginx_root_www_path: '/srv/www'
+
 # Default server root
-nginx_default_root: '/srv/www/sites/default/public'
+nginx_default_root: '{{ nginx_root_www_path + "/sites/default/public" }}'
 
 # Create global webroot directories?
 # Path: /srv/www/sites/*/public

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -146,4 +146,9 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
+  register: nginx_register_local_facts
+
+- name: Gather facts if they changed
+  action: setup
+  when: nginx_register_local_facts.changed
 

--- a/templates/etc/ansible/facts.d/nginx.fact.j2
+++ b/templates/etc/ansible/facts.d/nginx.fact.j2
@@ -12,5 +12,6 @@
 {%   set nginx_tpl_default_server = nginx_register_default_server_first           %}
 {% endif                                                                          %}
 {
+"www": "{{ nginx_root_www_path }}",
 "default_server": "{{ nginx_tpl_default_server }}"
 }


### PR DESCRIPTION
Other roles can access default 'debops.nginx' WWW path using Ansible
local facts, as 'ansible_local.nginx.www'.