### PR TITLE
Expose nginx system username in local facts

### DIFF
--- a/templates/etc/ansible/facts.d/nginx.fact.j2
+++ b/templates/etc/ansible/facts.d/nginx.fact.j2
@@ -12,6 +12,7 @@
 {%   set nginx_tpl_default_server = nginx_register_default_server_first           %}
 {% endif                                                                          %}
 {
+"user": "{{ nginx_user }}",
 "www": "{{ nginx_root_www_path }}",
 "default_server": "{{ nginx_tpl_default_server }}"
 }


### PR DESCRIPTION
Other roles can access this variable to for example grant webserver user
access to their files.