### PR TITLE
Add `debops.pki` dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ More information about `debops.nginx` can be found in the
 
 ### Role dependencies
 
+- `debops.secret`
+- `debops.pki`
 - `debops.ferm`
 - `debops.apt_preferences`
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,6 +4,9 @@ dependencies:
 
   - role: debops.secret
 
+  - role: debops.pki
+    when: nginx_pki is defined and nginx_pki
+
   - role: debops.apt_preferences
     tags: apt_preferences
     apt_preferences_dependent_list:


### PR DESCRIPTION
`debops.nginx` by default assumes that `debops.pki` has setup default ssl certificates. Making `debops.pki` a dependency ensures that this happens.