### PR TITLE
Fix issue with wrong nameserver in nginx config

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+v0.1.3
+------
+
+*Unreleased*
+
+- Be more explicit while getting the list of nameservers from
+  ``/etc/resolv.conf`` [drybjed]
+
 v0.1.2
 ------
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,7 +36,7 @@
     nginx_version: '{{ nginx_register_version.stdout | default("0.0") }}'
 
 - name: Get list of nameservers configured in /etc/resolv.conf
-  shell: grep nameserver /etc/resolv.conf | awk '{print $2}' | sed -e 'N;s/\n/ /'
+  shell: grep -E '^nameserver\s' /etc/resolv.conf | awk '{print $2}' | sed -e 'N;s/\n/ /'
   register: nginx_register_nameservers
   changed_when: False
 


### PR DESCRIPTION
Now nginx should select a nameserver correctly, ignoring comments like
'# nameserver' if they are present in the '/etc/resolv.conf' file.