### PR TITLE
Support for global client_max_body_size

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+v0.1.4
+------
+
+*Unreleased*
+
+- Add an option to set ``client_max_body_size`` globally for entire nginx
+  server, by setting ``nginx_http_client_max_body_size`` variable in Ansible
+  inventory. [drybjed]
+
 v0.1.3
 ------
 

--- a/templates/etc/nginx/nginx.conf.j2
+++ b/templates/etc/nginx/nginx.conf.j2
@@ -48,6 +48,10 @@ http {
 
 	add_header X-Clacks-Overhead "GNU Terry Pratchett";
 
+{% if nginx_http_client_max_body_size|d() and nginx_http_client_max_body_size %}
+        client_max_body_size {{ nginx_http_client_max_body_size }};
+
+{% endif %}
 {% if ((nginx_http_allow is defined and nginx_http_allow) or
        (nginx_http_auth_basic is defined and nginx_http_auth_basic) or
        (nginx_http_satisfy is defined and nginx_http_satisfy)) %}


### PR DESCRIPTION
You can set 'client_max_body_size' globally by setting
a 'nginx_http_client_max_body_size' variable in Ansible inventory.