### PR TITLE
Expose 'nginx_passenger_{root,ruby} variables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ v0.1.4
 
 - Add DebOps pre-tasks and post-tasks hooks. [drybjed]
 
+- Allow to override ``nginx_passenger_root`` and ``nginx_passenger_ruby``
+  variables using Ansible inventory variables. [drybjed]
+
 v0.1.3
 ------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,14 @@ nginx_user: 'www-data'
 # APT repository which will be added for Phusion Passenger support
 nginx_passenger_phusion_repo: 'deb https://oss-binaries.phusionpassenger.com/apt/passenger {{ ansible_distribution_release }} main'
 
+# Specify Phusion Passenger root paths manually (by default this variable is
+# detected automatically at Ansible run time)
+nginx_passenger_root: ''
+
+# Specify path to Ruby executable for Phusion Passenger manually (by default
+# this variable is detected automatically at Ansible run time)
+nginx_passenger_ruby: ''
+
 # Maximum number of Passenger processes
 nginx_passenger_max_pool_size: '{{ (ansible_processor_cores | int * 5) }}'
 

--- a/tasks/passenger_config.yml
+++ b/tasks/passenger_config.yml
@@ -8,6 +8,7 @@
 - name: Set passenger_root value
   set_fact:
    nginx_passenger_root: '{{ nginx_register_passenger_root.stdout }}'
+  when: nginx_passenger_root is undefined or not nginx_passenger_root
 
 - name: Detect passenger ruby
   shell: "passenger-config about ruby-command | grep Command | tail -1 | awk -F: '{print $2}'"
@@ -17,4 +18,5 @@
 - name: Set passenger_ruby value
   set_fact:
     nginx_passenger_ruby: '{{ nginx_register_passenger_ruby.stdout | trim }}'
+  when: nginx_passenger_ruby is undefined or not nginx_passenger_ruby
 


### PR DESCRIPTION
You can now override 'nginx_passenger_root' and 'nginx_passenger_ruby'
variables using Ansible inventory. If they are not specified, role will
try and find the correct values on its own.

Fixes #43