### PR TITLE
Add an option to control the Strict-Transport-Security header

### DIFF
--- a/templates/etc/nginx/sites-available/default.conf.j2
+++ b/templates/etc/nginx/sites-available/default.conf.j2
@@ -299,6 +299,11 @@
 #       locations: []
 #         nested list of locations to create in this location section
 #
+#   - item.hsts_enabled: true
+#       Optional. If this is set to true and SSL is enabled for this item, the
+#       Strict-Transport-Security header is set in the server's responses. If
+#       this is set to false, the Strict-Transport-Security header will not
+#       be set in the server's responses.
 #}
 {#
 
@@ -535,7 +540,9 @@ server {
         resolver                  {{ nginx_tpl_ocsp_resolver }} valid=300s;
         resolver_timeout          5s;
 {% endif %}
+{% if item.hsts_enabled is undefined or (item.hsts_enabled is defined and item.hsts_enabled) %}
         add_header                Strict-Transport-Security "max-age={{ nginx_hsts_age | default('15768000') }}{% if nginx_hsts_subdomains %}; includeSubDomains{% endif %}";
+{% endif %}
 
 {% if item.name is defined and item.name %}
 {% if item.redirect_from is defined and item.redirect_from %}


### PR DESCRIPTION
The universal inclusion of the Strict-Transport-Security header on SSL sites is causing CORS requests that are carried out over HTTP to fail in certain versions of Chrome and Firefox.

This pull request adds an option to remove the header on a per-item basis, which defaults to including the header.