### PR TITLE
Cast all possible values for `nginx_tpl_ssl`

### DIFF
--- a/templates/etc/nginx/sites-available/default.conf.j2
+++ b/templates/etc/nginx/sites-available/default.conf.j2
@@ -319,7 +319,7 @@
 
     ---- HTTPS, ports to listen on, default server, HTTPS redirect ----
 #}
-{% set nginx_tpl_ssl            = item.ssl        | default(item.pki       | default(nginx_pki | bool)) %}
+{% set nginx_tpl_ssl            = item.ssl        | default(item.pki       | default(nginx_pki)) | bool %}
 {% set nginx_tpl_listen         = item.listen     | default(['[::]:80'])       %}
 {% set nginx_tpl_listen_ssl     = item.listen_ssl | default(['[::]:443'])      %}
 {% set nginx_tpl_default_server = ''                                           %}


### PR DESCRIPTION
The template code was only casting `nginx_pki` as boolean. Moved the boolean cast to the filter used on the `nginx_tpl_ssl`. This lets the template code cast all possible values for `nginx_tpl_ssl` as boolean.