### PR TITLE
Added a default redirect code from HTTP to HTTPS

### DIFF
--- a/templates/etc/nginx/sites-available/default.conf.j2
+++ b/templates/etc/nginx/sites-available/default.conf.j2
@@ -68,6 +68,11 @@
 #       307 Temporary Redirect.
 #
 #
+#   - item.redirect_code_ssl: ''
+#       Optional. Specify HTTP code used in the redirect response from HTTP to 
+#       HTTPS, by default 301 Moved Permanently.
+#
+#
 #   - item.redirect_from: True or []
 #       Optional. Create a separate server { } section which will automatically
 #       redirect requests from specified list of server names (or all but the
@@ -333,6 +338,7 @@
 {%   set nginx_tpl_default_server_ssl = 'default_server ipv6only=off'          %}
 {% endif                                                                       %}
 {% set nginx_tpl_default_redirect_code = '307'                                 %}
+{% set nginx_tpl_default_redirect_code_ssl = '301'                             %}
 {% set nginx_tpl_http_redirect = item.redirect | default('https://$host$request_uri') %}
 {#
 
@@ -527,7 +533,7 @@ server {
 {% endif %}
 {% if nginx_tpl_ssl %}
 {% if (item.listen is undefined or (item.listen is defined and item.listen)) %}
-        return {{ item.redirect_code | default(nginx_tpl_default_redirect_code) }} {{ nginx_tpl_http_redirect }};
+        return {{ item.redirect_code_ssl | default(nginx_tpl_default_redirect_code_ssl) }} {{ nginx_tpl_http_redirect }};
 }
 
 server {
@@ -574,7 +580,7 @@ server {
     ---- Code below is shared between HTTP and HTTPS ----
 #}
 {% if (not nginx_tpl_ssl and ((item.redirect is defined and item.redirect) or (item.redirect_to_ssl is defined and item.redirect_to_ssl))) %}
-        return {{ item.redirect_code | default(nginx_tpl_default_redirect_code) }} {{ nginx_tpl_http_redirect }};
+        return {{ item.redirect_code_ssl | default(nginx_tpl_default_redirect_code_ssl) }} {{ nginx_tpl_http_redirect }};
 {% elif (nginx_tpl_ssl and (item.redirect_ssl is defined and item.redirect_ssl)) %}
         return {{ item.redirect_code | default(nginx_tpl_default_redirect_code) }} {{ item.redirect_ssl }};
 {% else %}


### PR DESCRIPTION
The `307` redirect code doesn't make sense for the SSL redirects. They are permanent moves. I added the new `redirect_code_ssl` option and default to handle them. It defaults to `301`.