### PR TITLE
Change how role gathers list of nameservers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,9 @@ v0.1.4
 - Filter out ``link-local`` IPv6 addresses from list of addresses that can
   access the ``/nginx_status`` page. [drybjed]
 
+- Change how list of nameservers is gathered from ``/etc/resolv.conf`` to fix
+  an issue with ``sed`` in shell command. [drybjed]
+
 v0.1.3
 ------
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,13 +60,13 @@
     nginx_version: '{{ nginx_register_version.stdout | default("0.0") }}'
 
 - name: Get list of nameservers configured in /etc/resolv.conf
-  shell: grep -E '^nameserver\s' /etc/resolv.conf | awk '{print $2}' | sed -e 'N;s/\n/ /'
+  shell: "grep -E '^nameserver\\s' /etc/resolv.conf | awk '{print $2}'"
   register: nginx_register_nameservers
   changed_when: False
 
 - name: Convert list of nameservers to Ansible list
   set_fact:
-    nginx_ocsp_resolvers: "{{ nginx_register_nameservers.stdout.split(' ') }}"
+    nginx_ocsp_resolvers: "{{ nginx_register_nameservers.stdout_lines }}"
   when: ((nginx_register_nameservers.stdout is defined and nginx_register_nameservers.stdout) and
          (nginx_ocsp_resolvers is undefined or
          (nginx_ocsp_resolvers is defined and not nginx_ocsp_resolvers)))


### PR DESCRIPTION
Instead of managing the list ourselves, let Ansible correctly feed the
data into a YAML list. This solves an issue with 'sed' use in shell
module.

Fixes https://github.com/ansible/ansible/issues/11899