### PR TITLE
Disable SSL support in nginx if it's not available

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,9 @@ v0.1.4
 - Use all available nameservers as OCSP resolvers instead of just the first
   one. User can also override the list of OCSP resolvers if needed. [drybjed]
 
+- Fix an issue where ``nginx`` used SSL configuration when support for it was
+  disabled in ``debops.pki`` (or it was not present). [drybjed]
+
 v0.1.3
 ------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -94,7 +94,7 @@ nginx_http_options: |
 nginx_default_keepalive_timeout: 60
 
 # Enable or disable support for PKI/SSL/TLS in nginx
-nginx_pki: '{{ (True if (ansible_local|d() and ansible_local.pki|d() and ansible_local.pki.enabled|d()) else False) | bool }}'
+nginx_pki: '{{ (True if (ansible_local|d() and ansible_local.pki|d() and ansible_local.pki.enabled|d() | bool) else False) | bool }}'
 
 # PKI base directory
 nginx_pki_path: '{% if (ansible_local is defined and ansible_local.pki is defined) %}{{ ansible_local.pki.base_path }}{% else %}/etc/pki{% endif %}'


### PR DESCRIPTION
This wasn't working since Ansible changed their boolean variable
handling. Now 'debops.nginx' should correctly behave if 'debops.pki'
support is not detected or it's disabled.