### PR TITLE
Ensure that `item.redirect_to_ssl` is evaluated as boolean.

### DIFF
--- a/templates/etc/nginx/sites-available/default.conf.j2
+++ b/templates/etc/nginx/sites-available/default.conf.j2
@@ -684,7 +684,7 @@
 {% if item.name is defined and item.name %}
 # nginx server configuration for:
 {% for address in item.name %}
-{% if nginx_tpl_ssl and item.redirect_to_ssl is undefined or (item.redirect_to_ssl is defined and not item.redirect_to_ssl) %}
+{% if nginx_tpl_ssl and not (item.redirect_to_ssl|d(True) | bool) %}
 #    - http://{{ address }}/
 {% endif %}
 #    - {{ "https" if nginx_tpl_ssl else "http" }}://{{ address }}/
@@ -760,7 +760,7 @@ server {
 {% endif %}
 {% if nginx_tpl_ssl %}
 {% if (item.listen is undefined or (item.listen is defined and item.listen)) %}
-{% if item.redirect_to_ssl is undefined or (item.redirect_to_ssl is defined and item.redirect_to_ssl) %}
+{% if item.redirect_to_ssl|d() | bool %}
         return {{ item.redirect_code_ssl | default(nginx_tpl_default_redirect_code_ssl) }} {{ nginx_tpl_http_redirect }};
 {% else %}
 {{ print_shared_nginx_server_block() }}

--- a/templates/etc/nginx/sites-available/default.conf.j2
+++ b/templates/etc/nginx/sites-available/default.conf.j2
@@ -760,10 +760,10 @@ server {
 {% endif %}
 {% if nginx_tpl_ssl %}
 {% if (item.listen is undefined or (item.listen is defined and item.listen)) %}
-{% if item.redirect_to_ssl|d() | bool %}
-        return {{ item.redirect_code_ssl | default(nginx_tpl_default_redirect_code_ssl) }} {{ nginx_tpl_http_redirect }};
-{% else %}
+{% if not (item.redirect_to_ssl|d(True) | bool) %}
 {{ print_shared_nginx_server_block() }}
+{% else %}
+        return {{ item.redirect_code_ssl | default(nginx_tpl_default_redirect_code_ssl) }} {{ nginx_tpl_http_redirect }};
 {% endif %}
 }
 

--- a/templates/etc/nginx/sites-available/proxy.conf.j2
+++ b/templates/etc/nginx/sites-available/proxy.conf.j2
@@ -16,7 +16,7 @@
 {%   if item.proxy_headers is undefined or item.proxy_headers | bool %}
                 proxy_set_header Host              $host;
                 proxy_set_header X-Real-IP         $remote_addr;
-{%     if item.redirect_to_ssl is defined and not item.redirect_to_ssl %}
+{%     if not (item.redirect_to_ssl|d(True) | bool) %}
                 set $X_Forwarded_Proto "http";
                 set $X_Forwarded_Port 80;
                 if ($https) {

--- a/templates/etc/nginx/sites-available/proxy.conf.j2
+++ b/templates/etc/nginx/sites-available/proxy.conf.j2
@@ -16,6 +16,7 @@
 {%   if item.proxy_headers is undefined or item.proxy_headers | bool %}
                 proxy_set_header Host              $host;
                 proxy_set_header X-Real-IP         $remote_addr;
+                proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
 {%     if not (item.redirect_to_ssl|d(True) | bool) %}
                 set $X_Forwarded_Proto "http";
                 set $X_Forwarded_Port 80;
@@ -26,10 +27,9 @@
                 proxy_set_header X-Forwarded-Proto $X_Forwarded_Proto;
                 proxy_set_header X-Forwarded-Port $X_Forwarded_Port;
 {%     else %}
-                proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
                 proxy_set_header X-Forwarded-Proto $scheme;
-{%     endif %}
                 proxy_set_header X-Forwarded-Port  {{ "443" if (nginx_tpl_ssl|d() and nginx_tpl_ssl | bool) else "80" }};
+{%     endif %}
 {%   elif item.proxy_headers|d() %}
 {{ item.proxy_headers | indent(16, true) }}
 {%   endif %}


### PR DESCRIPTION
@drybjed We discussed this the day before and now I hit such a problem … :wink: 

The problem occurred when passing a bool variable to another dict.

https://github.com/carlalexander/debops-wordpress/pull/29

```YAML
wordpress_varnish_server:
  redirect_to_ssl: '{{ wordpress_redirect_to_ssl }}'
```