### PR TITLE
Nginx.org package don't create the /var/lib/nginx folder and nginx start fails

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,20 +51,23 @@ nginx_run_path: '/run'
 # Directory where ``nginx`` log files are stored.
 nginx_log_path: '/var/log/nginx'
 
+# Root path of temporary files
+nginx_temp_root_path: '/var/lib/nginx'
+
 # Path of temporary client body files
-nginx_client_body_temp_path: '/var/lib/nginx/body'
+nginx_client_body_temp_path: '{{ nginx_temp_root_path }}/body'
 
 # Path of temporary FastCGI files
-nginx_fastcgi_temp_path: '/var/lib/nginx/fastcgi'
+nginx_fastcgi_temp_path: '{{ nginx_temp_root_path }}/fastcgi'
 
 # Path of temporary proxy files
-nginx_proxy_temp_path: '/var/lib/nginx/proxy'
+nginx_proxy_temp_path: '{{ nginx_temp_root_path }}/proxy'
 
 # Path of temporary sCGI files
-nginx_scgi_temp_path: '/var/lib/nginx/scgi'
+nginx_scgi_temp_path: '{{ nginx_temp_root_path }}/scgi'
 
 # Path of temporary iwsgi files
-nginx_uwsgi_temp_path: '/var/lib/nginx/uwsgi'
+nginx_uwsgi_temp_path: '{{ nginx_temp_root_path }}/uwsgi'
 
 # ---- Phusion Passenger support ----
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,9 @@
     - '/etc/nginx/sites-enabled'
     - '/etc/nginx/snippets'
 
+- include: nginx_org_directories.yml
+  when: nginx_flavor == 'nginx.org'
+
 - name: Divert default.conf in case nginx nginx.org flavor is used
   command: dpkg-divert --quiet --local --divert /etc/nginx/conf.d/default.conf.dpkg-divert
            --rename /etc/nginx/conf.d/default.conf

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,9 +34,7 @@
     - '/etc/nginx/sites-available'
     - '/etc/nginx/sites-enabled'
     - '/etc/nginx/snippets'
-
-- include: nginx_org_directories.yml
-  when: nginx_flavor == 'nginx.org'
+    - '{{ nginx_temp_root_path }}'
 
 - name: Divert default.conf in case nginx nginx.org flavor is used
   command: dpkg-divert --quiet --local --divert /etc/nginx/conf.d/default.conf.dpkg-divert

--- a/tasks/nginx_org_directories.yml
+++ b/tasks/nginx_org_directories.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Create default temp nginx directory
+  file:
+    path: '{{ nginx_temp_root_path }}'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'

--- a/tasks/nginx_org_directories.yml
+++ b/tasks/nginx_org_directories.yml
@@ -1,9 +1,0 @@
----
-
-- name: Create default temp nginx directory
-  file:
-    path: '{{ nginx_temp_root_path }}'
-    state: 'directory'
-    owner: 'root'
-    group: 'root'
-    mode: '0755'


### PR DESCRIPTION
When you use nginx.org flavor it have to create the /var/lib/nginx folder or the nginx start will fail.