### PR TITLE
password can be set in nginx_htpasswd list

### DIFF
--- a/tasks/nginx_htpasswd.yml
+++ b/tasks/nginx_htpasswd.yml
@@ -21,7 +21,7 @@
   htpasswd:
     path: '{{ nginx_private_path + "/" + item.0.name }}'
     name: '{{ item.1 }}'
-    password: '{{ lookup("password", nginx_htpasswd_secret_path + "/" + item.0.name + "/" + item.1) }}'
+    password: '{{ item.0.password if item.0.password is defined else lookup("password", nginx_htpasswd_secret_path + "/" + item.0.name + "/" + item.1) }}'
     state: '{{ item.0.state | default("present") }}'
     owner: 'root'
     group: '{{ nginx_user }}'


### PR DESCRIPTION
I manage nginx_htpasswd with ansible-vault so I want to put passwd directly in nginx_htpasswd list.
For instance we can do that:

    nginx_htpasswd:
      - name: user1
        users: [ 'user1' ]
        password: 'ihah1aiG2eimi5o'
