### PR TITLE
Expose nginx status IP's via Ansible facts

### DIFF
--- a/templates/etc/ansible/facts.d/nginx.fact.j2
+++ b/templates/etc/ansible/facts.d/nginx.fact.j2
@@ -33,6 +33,8 @@ cat << EOF
 "user": "{{ nginx_user }}",
 "www": "{{ nginx_www }}",
 "flavor": "{{ nginx_flavor }}",
-"version": "$nginx_version"
+"version": "$nginx_version",
+"status_localhost": {{ nginx_status_localhost | to_nice_json }},
+"status": {{ nginx_status | to_nice_json }}
 }
 EOF


### PR DESCRIPTION
Expose nginx status IP's via Ansible facts as ansible_local.nginx.status_localhost and ansible_local.nginx.status for use by other roles