### PR TITLE
Remove index.php from try_files.

### DIFF
--- a/templates/etc/nginx/sites-available/php.conf.j2
+++ b/templates/etc/nginx/sites-available/php.conf.j2
@@ -11,7 +11,7 @@
 
 {% endblock %}
 {% block nginx_tpl_block_location_root %}
-                try_files $uri $uri/ /index.php =404;
+                try_files $uri $uri/ $uri.php;
 {% endblock %}
 {% block nginx_tpl_block_custom_status_locations %}
 {%   if item.php_status|d()|bool %}

--- a/templates/etc/nginx/sites-available/php5.conf.j2
+++ b/templates/etc/nginx/sites-available/php5.conf.j2
@@ -63,7 +63,7 @@
 
 {% endblock %}
 {% block nginx_tpl_block_location_root %}
-                try_files $uri $uri/ /index.php =404;
+                try_files $uri $uri/ $uri.php;
 {% endblock %}
 {% block nginx_tpl_block_custom_status_locations %}
 {% if item.php5_status|d(nginx_php5_status) and (nginx_status or nginx_status_localhost) %}


### PR DESCRIPTION
try_file is executed in the current context, "location /" in our
case, and would serve the php script as a static file.

Just return a 404 instead.