### PR TITLE
Make default_server checks require exact name

### DIFF
--- a/templates/etc/nginx/sites-available/default.conf.j2
+++ b/templates/etc/nginx/sites-available/default.conf.j2
@@ -26,7 +26,7 @@
 {% set nginx_tpl_ipv6only = []                                                 %}
 {% if nginx_register_default_server|d() %}
 {%   for name in ([ item.name ] if item.name is string else item.name)         %}
-{%     if (name in nginx_register_default_server or
+{%     if (name == nginx_register_default_server or
           not name and nginx_register_default_server == "default")             %}
 {%       set _ = nginx_tpl_default_server.append('default_server')             %}
 {%       if (nginx_manage_ipv6only | bool)                                     %}
@@ -39,7 +39,7 @@
 {% set nginx_tpl_ipv6only_ssl = []                                             %}
 {% if nginx_register_default_server_ssl|d() %}
 {%   for name in ([ item.name ] if item.name is string else item.name)         %}
-{%     if (name in nginx_register_default_server_ssl or
+{%     if (name == nginx_register_default_server_ssl or
            not name and nginx_register_default_server_ssl == "default")        %}
 {%        set _ = nginx_tpl_default_server_ssl.append('default_server')        %}
 {%       if (nginx_manage_ipv6only | bool)                                     %}


### PR DESCRIPTION
Consider the following nginx role variables:
```
nginx_default_name: 'www.domain.tld'
nginx_default_ssl_name: 'www.domain.tld'

nginx_servers:
  - name: 'www.domain.tld'
  - name: 'domain.tld'

```

The conditional `name in nginx_register_default_server` causes both of the defined servers to match, and you end up with multiple default_server declarations in the `sites-enabled/*.conf` files.