### PR TITLE
Allow to define access log format

### DIFF
--- a/docs/defaults-detailed.rst
+++ b/docs/defaults-detailed.rst
@@ -517,6 +517,10 @@ Logging and monitoring
   Name of the error log file.
   The suffix ``.log`` will be added automatically.
 
+``access_log_format``
+  Optional. Name of the access log format.
+  Custom log formats can be defined using ``nginx_http_options`` variable.
+
 ``status``
   Optional, list of strings.
   Enable nginx server status page and allow access from the given list of IP

--- a/templates/etc/nginx/sites-available/default.conf.j2
+++ b/templates/etc/nginx/sites-available/default.conf.j2
@@ -206,7 +206,13 @@
 
 {% block nginx_tpl_block_log %}
 {% if item.name|d() %}
-        access_log {{ (item.log_path | d(nginx_log_path)) + '/' + item.access_log | d(item.filename | d(item.name if item.name is string else item.name[0]) + '_access') }}.log;
+{%     set nginx_tpl_access_log_format = ''                                 %}
+{%     if item.access_log_format is defined                                 %}
+{%         set nginx_tpl_access_log_format = ' ' +  item.access_log_format  %}
+{%     elif nginx_access_log_format is defined                              %}
+{%         set nginx_tpl_access_log_format = ' ' +  nginx_access_log_format %}
+{%     endif                                                                %}
+        access_log {{ (item.log_path | d(nginx_log_path)) + '/' + item.access_log | d(item.filename | d(item.name if item.name is string else item.name[0]) + '_access') }}.log{{ nginx_tpl_access_log_format }};
         error_log {{ (item.log_path | d(nginx_log_path)) + '/' + item.error_log | d(item.filename | d(item.name if item.name is string else item.name[0]) + '_error') }}.log;
 
 {% endif %}


### PR DESCRIPTION
Example:

```
nginx_http_options: |
  log_format timed_combined '$remote_addr - $remote_user [$time_local] '
                    '"$request" $status $body_bytes_sent '
                    '"$http_referer" "$http_user_agent" '
                    '$request_time $upstream_response_time $pipe';

nginx_access_log_format: 'timed_combined'
```