### PR TITLE
Use https to download nginx package

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,7 +52,7 @@ nginx__flavor_apt_key_id_map:
   'passenger': '16378A33A6EF16762922526E561F9B9CAC40B2F7'
 
 nginx__flavor_apt_repository_map:
-  'nginx.org': 'deb http://nginx.org/packages/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release }} nginx'
+  'nginx.org': 'deb https://nginx.org/packages/{{ ansible_distribution | lower }}/ {{ ansible_distribution_release }} nginx'
   'passenger': 'deb https://oss-binaries.phusionpassenger.com/apt/passenger {{ ansible_distribution_release }} main'
 
 nginx__flavor_packages: '{{ nginx_flavor_package_map[nginx_flavor] }}'


### PR DESCRIPTION
Fixes #158 