### PR TITLE
Add an 'extras' variant to install nginx-extras

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -65,6 +65,9 @@ nginx_flavor_package_map:
   # Default version from Debian
   'full': [ 'nginx-full' ]
 
+  # Extras version from Debian
+  'extras': [ 'nginx-extras' ]
+
   # nginx with support for Phusion Passenger compiled in. Requires external APT
   # repository. See https://phusionpassenger.com/ for more details.
   'passenger': [ 'nginx-extras', 'passenger', 'ruby' ]


### PR DESCRIPTION
Some modules are only available if the nginx-extras package is
installed, but this does not mean that one neccessarily wants to run a
phusion passenger server.