### PR TITLE
fix missing module include for stretch

### DIFF
--- a/templates/etc/nginx/nginx.conf.j2
+++ b/templates/etc/nginx/nginx.conf.j2
@@ -6,6 +6,8 @@ user {{ nginx_user }};
 {% endif %}
 pid {{ nginx_run_path }}/nginx.pid;
 
+include /etc/nginx/modules-enabled/*.conf;
+
 # Default error_log
 error_log {{ nginx_http_error_log | default(nginx_log_path + '/error.log') }};
 


### PR DESCRIPTION
Since Debian Stretch additional modules configs from Nginx are in a separate dir.

This should have no disadvantages to older version before Stretch, because the `include` gets ignored if the directory does not exist. (also tested on Jessie)

It is also not to use the `nginx_extra_options` variable, then this error happend:
`[emerg] "load_module" directive is specified too late in ....`
